### PR TITLE
Resolve swab() conflict on macOS by adjusting includes

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -24,8 +24,6 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
-#include "tinyglib.h"
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
@@ -47,6 +45,7 @@
 #endif
 
 #include "libslirp.h"
+#include "tinyglib.h"
 
 #ifdef __GNUC__
 #define SLIRP_PACKED_BEGIN

--- a/src/vmstate.c
+++ b/src/vmstate.c
@@ -39,10 +39,6 @@
  */
 #include <assert.h>
 #include <errno.h>
-#include <string.h>
-#include "tinyglib.h"
-
-#include "stream.h"
 #include "vmstate.h"
 
 static int get_nullptr(SlirpIStream *f, void *pv, size_t size,


### PR DESCRIPTION
On macOS, both `<unistd.h>` and `<string.h>` declar `swab()`, which may result in a conflicting types error due to differences in declaration qualifiers, which can result in a "conflicting types for 'swab'" error during compilation.

According to POSIX, `swab()` is officially declared in `<unistd.h>`. macOS also declares it in `<string.h>` for compatibility, but without proper include guards. This PR resolves the issue by:
- Reordering includes in `util.h` to ensure `<unistd.h>` appears before `<string.h>`
- Removing a redundant include in vmstate.c

Tested on macOS 12.1